### PR TITLE
Add support for OpenRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Transform your Hacker News experience with intelligent navigation, AI-powered su
     * Set up billing alerts
 
 ### OpenRouter
+[OpenRouter](https://openrouter.ai/) is a service that provides unified access to multiple large language models (LLMs) through a single API. This platform simplifies the integration and management of different AI models, such as GPT, Claude, and Grok, allowing developers to switch between them without dealing with separate APIs.
+
 1. Requirements:
     * OpenRouter API key
     * Active OpenRouter account with credits

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 [![Basic features video](http://img.youtube.com/vi/uPRh7UKYd8E/maxresdefault.jpg)](https://www.youtube.com/watch?v=uPRh7UKYd8E)
 
 > [!TIP]
-> You can also find this extension on the [Chrome Web Store](https://chromewebstore.google.com/detail/hackernews-comment-enhanc/khfcainelcaedmmhjicphbkpigklejgf).
+> You can also find this extension on the [Chrome Web Store](https://chromewebstore.google.com/detail/hacker-news-companion/khfcainelcaedmmhjicphbkpigklejgf).
 
 ## 🚀 Quick Start Guide
-1. Install from [Chrome Web Store](https://chromewebstore.google.com/detail/hackernews-comment-enhanc/khfcainelcaedmmhjicphbkpigklejgf)
+1. Install from [Chrome Web Store](https://chromewebstore.google.com/detail/hacker-news-companion/khfcainelcaedmmhjicphbkpigklejgf)
 2. Navigate to [Hacker News](https://news.ycombinator.com)
 3. Press '?' to view keyboard shortcuts
 4. Choose your preferred AI provider in extension settings
@@ -25,7 +25,7 @@ Transform your Hacker News experience with intelligent navigation, AI-powered su
   * Multiple AI provider options
   * Summarize entire threads or specific comment branches
   * Use Chrome's built-in AI for local processing
-  * Connect to OpenAI, Anthropic, or Ollama for advanced summaries
+  * Connect to OpenAI, Anthropic, Ollama or OpenRouterfor advanced summaries
 
 * **Enhanced Comment Navigation**
     * Quick-jump between comments by the same author
@@ -117,6 +117,17 @@ Transform your Hacker News experience with intelligent navigation, AI-powered su
     * Monitor API usage
     * Set up billing alerts
 
+### OpenRouter
+1. Requirements:
+    * OpenRouter API key
+    * Active OpenRouter account with credits
+
+2. Setup Steps:
+    * Generate an API key at [OpenRouter](https://openrouter.ai/settings/keys)
+    * Enter API key in extension settings (click on the extension icon)
+    * Enter your preferred model
+        * A list of available models can be found at [OpenRouter models](https://openrouter.ai/models)
+        * `anthropic/claude-3.5-sonnet` is our default and a great model to start with
 
 ## ⌨️ Keyboard Shortcuts
 

--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,8 @@
   "optional_host_permissions": [
     "https://api.openai.com/v1/chat/completions/*",
     "https://api.anthropic.com/v1/messages/*",
-    "http://localhost:11434/*"
+    "http://localhost:11434/*",
+    "https://openrouter.ai/api/v1/*"
   ],
   "options_ui": {
     "page": "options.html",

--- a/options.html
+++ b/options.html
@@ -248,7 +248,7 @@
                                 <input type="text"
                                        id="openrouter-model"
                                        name="openrouter-model"
-                                       value="claude-3-opus-CHANGEME"
+                                       value="anthropic/claude-3.5-sonnet"
                                        placeholder="Enter model identifier"
                                        class="col-start-1 row-start-1 block w-full rounded-md bg-white px-3 py-1.5 text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 text-sm">
                             </div>

--- a/options.html
+++ b/options.html
@@ -199,12 +199,13 @@
                                 </div>
                             </details>
                         </div>
-
                         <div>
                             <label for="openai-model" class="block text-sm font-medium text-gray-900">Select OpenAI Model</label>
                             <div class="mt-2 grid grid-cols-1">
-                                <select id="openai-model" name="openai-model" class="col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-1.5 pl-3 pr-8  text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 text-sm">
-                                    <option value="gpt-4-turbo">GPT-4 Turbo</option>
+                                <select id="openai-model"
+                                        name="openai-model"
+                                        class="col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-1.5 pl-3 pr-8 text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 text-sm">
+                                    <option value="gpt-4">GPT-4</option>
                                     <option value="gpt-3.5-turbo">GPT-3.5 Turbo</option>
                                 </select>
                                 <svg class="pointer-events-none col-start-1 row-start-1 mr-2 size-5 self-center justify-self-end text-gray-500 sm:size-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" data-slot="icon">
@@ -212,21 +213,59 @@
                                 </svg>
                             </div>
                         </div>
-
                     </div>
                 </div>
 
-            </div>
-        </fieldset>
+                <!-- OpenRouter -->
+                <div class="space-y-3">
+                    <div class="flex items-center">
+                        <input id="openrouter" name="provider-selection" type="radio"
+                               class="relative size-4 appearance-none rounded-full border border-gray-300 bg-white before:absolute before:inset-1 before:rounded-full before:bg-white checked:border-indigo-600 checked:bg-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:before:bg-gray-400 forced-colors:appearance-auto forced-colors:before:hidden [&:not(:checked)]:before:hidden">
+                        <label for="openrouter" class="ml-3 block text-sm font-medium text-gray-900">OpenRouter</label>
+                    </div>
+                    <div class="ml-7 space-y-3">
+                        <div class="mt-2 grid grid-cols-1">
+                            <label for="openrouter-key" class="sr-only">Enter OpenRouter API Key</label>
+                            <input type="password"
+                                   id="openrouter-key"
+                                   name="openrouter-key"
+                                   placeholder="Enter OpenRouter API Key"
+                                   class="col-start-1 row-start-1 block w-full rounded-md bg-white px-3 py-1.5 text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 text-sm">
+                            <details class="col-start-1 row-start-1 justify-self-end self-center mr-3 inline-block relative">
+                                <summary class="list-none text-gray-400 hover:text-gray-500 cursor-pointer">
+                                    <svg class="size-5 sm:size-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                                        <path fill-rule="evenodd" d="M15 8A7 7 0 1 1 1 8a7 7 0 0 1 14 0Zm-6 3.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM7.293 5.293a1 1 0 1 1 .99 1.667c-.459.134-1.033.566-1.033 1.29v.25a.75.75 0 1 0 1.5 0v-.115a2.5 2.5 0 1 0-2.518-4.153.75.75 0 1 0 1.061 1.06Z" clip-rule="evenodd" />
+                                    </svg>
+                                </summary>
+                                <div class="absolute right-0 mt-2 w-72 bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 z-10 p-4 text-sm text-gray-600">
+                                    🔑 API key is securely stored in your browser's local storage and can sync across your devices with browser sync. The key is transmitted only to the selected LLM provider when making requests.
+                                </div>
+                            </details>
+                        </div>
+                        <div>
+                            <label for="openrouter-model" class="block text-sm font-medium text-gray-900">Enter OpenRouter Model</label>
+                            <div class="mt-2 grid grid-cols-1">
+                                <input type="text"
+                                       id="openrouter-model"
+                                       name="openrouter-model"
+                                       value="claude-3-opus-CHANGEME"
+                                       placeholder="Enter model identifier"
+                                       class="col-start-1 row-start-1 block w-full rounded-md bg-white px-3 py-1.5 text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 text-sm">
+                            </div>
+                        </div>
+                    </div>
+                </div>
 
-        <div class="mt-6 flex items-center justify-end gap-x-6">
-            <button type="button" class="text-sm font-semibold text-gray-900">Cancel</button>
-            <button type="submit"
-                    class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
-                Save
-            </button>
-        </div>
-    </form>
-</div>
+                <div class="mt-6 flex items-center justify-end gap-x-6">
+                    <button type="button" class="text-sm font-semibold text-gray-900">Cancel</button>
+                    <button type="submit"
+                            class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+                        Save
+                    </button>
+                </div>
+            </fieldset>
+
+        </form>
+    </div>
 </body>
 </html>

--- a/options.js
+++ b/options.js
@@ -102,7 +102,7 @@ async function loadSettings() {
             // Set OpenRouter settings
             if (settings.openrouter) {
                 document.getElementById('openrouter-key').value = settings.openrouter.apiKey || '';
-                document.getElementById('openrouter-model').value = settings.openrouter.model || 'claude-3-opus-CHANGEME';
+                document.getElementById('openrouter-model').value = settings.openrouter.model || 'anthropic/claude-3.5-sonnet';
             }
         }
     } catch (error) {

--- a/options.js
+++ b/options.js
@@ -13,6 +13,10 @@ async function saveSettings() {
         },
         ollama: {
             model: document.getElementById('ollama-model').value
+        },
+        openrouter: {
+            apiKey: document.getElementById('openrouter-key').value,
+            model: document.getElementById('openrouter-model').value
         }
     };
 
@@ -94,6 +98,12 @@ async function loadSettings() {
             if (settings.ollama) {
                 document.getElementById('ollama-model').value = settings.ollama.model || 'llama2';
             }
+
+            // Set OpenRouter settings
+            if (settings.openrouter) {
+                document.getElementById('openrouter-key').value = settings.openrouter.apiKey || '';
+                document.getElementById('openrouter-model').value = settings.openrouter.model || 'claude-3-opus-CHANGEME';
+            }
         }
     } catch (error) {
         console.error('Error loading settings:', error);
@@ -102,7 +112,6 @@ async function loadSettings() {
 
 // Initialize event listeners and load settings
 document.addEventListener('DOMContentLoaded', async () => {
-
     // Fetch Ollama models before loading other settings
     await fetchOllamaModels();
 
@@ -130,10 +139,12 @@ document.addEventListener('DOMContentLoaded', async () => {
             const openaiInputs = document.querySelectorAll('#openai-key, #openai-model');
             const anthropicInputs = document.querySelectorAll('#anthropic-key, #anthropic-model');
             const ollamaInputs = document.querySelectorAll('#ollama-model');
+            const openrouterInputs = document.querySelectorAll('#openrouter-key, #openrouter-model');
 
             openaiInputs.forEach(input => input.disabled = radio.id !== 'openai');
             anthropicInputs.forEach(input => input.disabled = radio.id !== 'anthropic');
             ollamaInputs.forEach(input => input.disabled = radio.id !== 'ollama');
+            openrouterInputs.forEach(input => input.disabled = radio.id !== 'openrouter');
         });
     });
 


### PR DESCRIPTION
Hey guys! I saw @annjose's announcement [post on LinkedIn ](https://www.linkedin.com/posts/annjose_hacker-news-companion-chrome-extension-activity-7278869231008407552-Ijra) and thought maybe this could be useful? Feel free to reject if this is out of scope! 

Lately I've been working on a lot of stuff that uses different LLMs and OpenRouter has been very helpful in allowing me to switch between (hosted) models super quickly and cheaply. 

[OpenRouter](https://openrouter.ai/) provides direct access to various AI models, including those from different providers. The service allows users to interact with models through their own infrastructure (and pricing), separate from the original providers' subscription tiers. It can save $ if you want to utilize multiple LLMs because you don't have multiple subscriptions in various tier levels. 

Also, OpenRouter's API is basically a clone of OpenAI which made this addition very easy! 

## In this PR

I've attempted to add support for OpenRouter with the following: 

- Update to settings UI where a user can save API key + their preferred model (default to sonet)
- Add a summarize function (90% copy of the OpenAI summarize function)
- Update README with some notes on setup and where to find models

## Screenshots  

### Summarization with Grok
<img width="1452" alt="Screenshot 2025-01-10 at 6 57 47 PM" src="https://github.com/user-attachments/assets/031a15ca-c2ee-4c40-9e4b-400d26562448" />

### Settings Update
<img width="1452" alt="Screenshot 2025-01-10 at 7 30 43 PM" src="https://github.com/user-attachments/assets/b753fe3a-46f2-4987-a28d-b01aec15eea6" />

### OpenRouter Activity Log with Different Models
<img width="1207" alt="Screenshot 2025-01-10 at 7 26 42 PM" src="https://github.com/user-attachments/assets/036bcff5-a65a-4b8d-8bfc-e20a7b1fea8d" />
